### PR TITLE
refresh tag suggestion while typing non latin character

### DIFF
--- a/src/fuzzy_panel.py
+++ b/src/fuzzy_panel.py
@@ -57,10 +57,16 @@ addHook("night_mode_state_changed", refresh_night_mode_state)
 class PanelInputLine(QLineEdit):
     down_pressed = pyqtSignal()
     up_pressed = pyqtSignal()
+    im_changed = pyqtSignal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
+    def inputMethodEvent(self, event):
+        self.setAttribute(Qt.WA_InputMethodEnabled)
+        super().inputMethodEvent(event)
+        self.im_changed.emit(self.text() + event.preeditString())
+        
     def keyPressEvent(self, event):
         super().keyPressEvent(event)
         mod = mw.app.keyboardModifiers() & Qt.ControlModifier
@@ -179,6 +185,7 @@ class FilterDialog(QDialog):
         '''
 
         # connections
+        self.input_line.im_changed.connect(self.text_changed)
         self.input_line.textChanged.connect(self.text_changed)
         self.input_line.returnPressed.connect(self.return_pressed)
         self.input_line.down_pressed.connect(self.down_pressed)
@@ -233,10 +240,11 @@ class FilterDialog(QDialog):
                 item.setHidden(True)
         self.list_box.setCurrentRow(0)
 
-    def text_changed(self):
+    def text_changed(self, search_string = None):
         if self.oldtext in self.keys:
             self.keys.remove(self.oldtext)
-        search_string = self.input_line.text()
+        if not search_string:
+            search_string = self.input_line.text()
         self.oldtext = search_string
         self.keys.append(search_string)
         FILTER_WITH = "slzk_mod"   # "slzk", "fuzzyfinder"

--- a/src/fuzzy_panel.py
+++ b/src/fuzzy_panel.py
@@ -61,9 +61,10 @@ class PanelInputLine(QLineEdit):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        if not self.testAttribute(Qt.WA_InputMethodEnabled):
+            self.setAttribute(Qt.WA_InputMethodEnabled)
 
     def inputMethodEvent(self, event):
-        self.setAttribute(Qt.WA_InputMethodEnabled)
         super().inputMethodEvent(event)
         self.im_changed.emit(self.text() + event.preeditString())
         


### PR DESCRIPTION
For some non-latin languages(Korean and others), a character isn't typed in with just one key press. For Korean, a character can take up to 5 keyboard presses to type in, and can take up to 2 more for the software to realize that I am now typing the next character, which only then KeyPressed and textChanged is triggered. 

This commit changes the way this addon detects the input was changed and should perform the search, from when it realizes the complete character was typed in, to while the character is still being typed in.